### PR TITLE
Fix createConnection callback missing

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -43,11 +43,11 @@ function wrapConnect(conn) {
 
 exports = module.exports = function (anyDB) {
   return {
-    createConnection: function (url) {
-      return wrapConnect(anyDB.createConnection(url));
+    createConnection: function (url, callback) {
+      return wrapConnect(anyDB.createConnection(url, callback));
     },
-    connect: function (url) {
-      return wrapConnect(anyDB.createConnection(url));
+    connect: function (url, callback) {
+      return wrapConnect(anyDB.createConnection(url, callback));
     },
     createPool: function (url, prm) {
       var pool = anyDB.createPool(url, prm);


### PR DESCRIPTION
Most of adapter support callback when creating database connection but
the wrapper of any-db-bind miss it.
